### PR TITLE
Added PageSize/Page support for instrument list. Added specific response for instrument.

### DIFF
--- a/src/main/java/com/fdu/capstone_instrument_shopping_center/controllers/InstrumentController.java
+++ b/src/main/java/com/fdu/capstone_instrument_shopping_center/controllers/InstrumentController.java
@@ -3,9 +3,11 @@ package com.fdu.capstone_instrument_shopping_center.controllers;
 import com.fdu.capstone_instrument_shopping_center.entity.Instrument;
 import com.fdu.capstone_instrument_shopping_center.entity.UserInfo;
 import com.fdu.capstone_instrument_shopping_center.repositories.InstrumentRepository;
+import com.fdu.capstone_instrument_shopping_center.response.InstrumentListResponse;
 import com.fdu.capstone_instrument_shopping_center.response.InstrumentResponse;
 import com.fdu.capstone_instrument_shopping_center.response.Response;
 import com.fdu.capstone_instrument_shopping_center.services.InstrumentService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +15,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/Instrument")
+@Slf4j
 public class InstrumentController {
 
     @Autowired
@@ -22,7 +25,15 @@ public class InstrumentController {
     InstrumentService instrumentService;
 
     @GetMapping("/getInstrumentList")
-    public List<Instrument> getInstrumentList() {
+    public InstrumentListResponse getInstrumentListByPage(
+            @RequestParam(value = "pageSize", defaultValue = "5", required = false) int pageSize,
+            @RequestParam(value = "page", defaultValue = "1", required = false) int page
+    ) {
+        return instrumentService.getInstrumentResponseByPage(pageSize, page);
+    }
+
+    @GetMapping("/getAllInstrumentList")
+    public List<Instrument> getAllInstrumentList() {
         return instrumentService.getAllInstruments();
     }
 
@@ -31,4 +42,6 @@ public class InstrumentController {
         instrumentService.addNewInstrument(instrument);
         return new InstrumentResponse(true, instrument);
     }
+
+
 }

--- a/src/main/java/com/fdu/capstone_instrument_shopping_center/response/InstrumentListResponse.java
+++ b/src/main/java/com/fdu/capstone_instrument_shopping_center/response/InstrumentListResponse.java
@@ -1,0 +1,22 @@
+package com.fdu.capstone_instrument_shopping_center.response;
+
+import com.fdu.capstone_instrument_shopping_center.entity.Instrument;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class InstrumentListResponse extends Response{
+
+    private List<Instrument> instrumentList;
+    private int total;
+    public InstrumentListResponse(boolean success, List<Instrument> instrumentList, int total) {
+        super(success);
+        this.instrumentList = instrumentList;
+        this.total = total;
+    }
+
+
+}

--- a/src/main/java/com/fdu/capstone_instrument_shopping_center/services/Impl/InstrumentServiceImpl.java
+++ b/src/main/java/com/fdu/capstone_instrument_shopping_center/services/Impl/InstrumentServiceImpl.java
@@ -2,19 +2,26 @@ package com.fdu.capstone_instrument_shopping_center.services.Impl;
 
 import com.fdu.capstone_instrument_shopping_center.entity.Instrument;
 import com.fdu.capstone_instrument_shopping_center.repositories.InstrumentRepository;
+import com.fdu.capstone_instrument_shopping_center.response.InstrumentListResponse;
 import com.fdu.capstone_instrument_shopping_center.services.InstrumentService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Slf4j
 public class InstrumentServiceImpl implements InstrumentService {
     static final String UNKNOWN = "unknown";
 
-    @Autowired
-    InstrumentRepository instrumentRepository;
+    private final InstrumentRepository instrumentRepository;
 
+    @Autowired
+    public InstrumentServiceImpl(InstrumentRepository instrumentRepository) {
+        this.instrumentRepository = instrumentRepository;
+    }
 
     @Override
     public List<Instrument> getAllInstruments() {
@@ -38,4 +45,25 @@ public class InstrumentServiceImpl implements InstrumentService {
         instrument.setImageURL(UNKNOWN);
         return instrument;
     }
+
+    @Override
+    public InstrumentListResponse getInstrumentResponseByPage(int pageSize, int page) {
+        if(pageSize <= 0 || page <= 0) {
+            return new InstrumentListResponse(false, new ArrayList<>(), 0);
+        }
+        // Return Instrument List based on pageSize and current page number.
+        List<Instrument> allInstrument = getAllInstruments();
+        int total = allInstrument.size();
+        // Calculate the instrument index , including starting index and ending index
+        int startIndex = (page - 1) * pageSize;
+        if(startIndex >= total) {
+            // Current page has no product , because it is larger than total instruments
+            log.warn("Current page: {} has no instruments to show.", page);
+            return new InstrumentListResponse(true, new ArrayList<>(), total);
+        }
+        int endIndex = Math.min(total, startIndex + pageSize);
+        List<Instrument> resInstrumentList = allInstrument.subList(startIndex, endIndex);
+        return new InstrumentListResponse(true, resInstrumentList, total);
+    }
+
 }

--- a/src/main/java/com/fdu/capstone_instrument_shopping_center/services/Impl/UserInfoServiceImpl.java
+++ b/src/main/java/com/fdu/capstone_instrument_shopping_center/services/Impl/UserInfoServiceImpl.java
@@ -16,8 +16,13 @@ public class UserInfoServiceImpl implements UserInfoService {
     static final int RANDOM_LEN = 6;
     static final SecureRandom RANDOM = new SecureRandom();
 
+
+    private final UserInfoRepository userInfoRepository;
+
     @Autowired
-    UserInfoRepository userInfoRepository;
+    public UserInfoServiceImpl(UserInfoRepository userInfoRepository) {
+        this.userInfoRepository = userInfoRepository;
+    }
 
     @Override
     public List<UserInfo> getAllUserInfo() {

--- a/src/main/java/com/fdu/capstone_instrument_shopping_center/services/InstrumentService.java
+++ b/src/main/java/com/fdu/capstone_instrument_shopping_center/services/InstrumentService.java
@@ -1,6 +1,7 @@
 package com.fdu.capstone_instrument_shopping_center.services;
 
 import com.fdu.capstone_instrument_shopping_center.entity.Instrument;
+import com.fdu.capstone_instrument_shopping_center.response.InstrumentListResponse;
 
 import java.util.List;
 
@@ -10,4 +11,6 @@ public interface InstrumentService {
     Instrument addNewInstrument(Instrument instrument);
 
     Instrument addNewInstrument(String name, String brand, String category);
+
+    InstrumentListResponse getInstrumentResponseByPage(int pageSize, int page);
 }


### PR DESCRIPTION
Added InstrumentList query by pageSize and page.
In general, if we have 50 instruments, and pageSize is 10, page is 3, then the backend will return the list of instruments from index number 21 to 30.
Noted that pageSize and page must be greater than 0. The default value of pageSize is 5, the page is  1.
Added InstrumentListResponse. Added success/ Code/ message/ total(InstrumentNumber)/ InstrumentList section in JSON format.

Optimized some controllers for constructor injection.